### PR TITLE
refactor: model marketplace as graph + DAG constructs

### DIFF
--- a/fintech/fix-trading/estream-component.toml
+++ b/fintech/fix-trading/estream-component.toml
@@ -22,7 +22,7 @@ visibility = "open"
 min_version = "0.8.0"
 
 [component.dependencies]
-esf-trading = "^1.0.0"
+data-trading = "^1.0.0"
 
 [component.schemas]
 provides = ["EStreamOrder", "EStreamFill", "EStreamQuote", "EStreamMarketData"]

--- a/fintech/fix-trading/fix_trading_gateway.fl
+++ b/fintech/fix-trading/fix_trading_gateway.fl
@@ -19,7 +19,7 @@
 // Install: estream marketplace install fix-trading-gateway
 //
 // Data Flow:
-//   FIX TCP → fix_parse → fix_session → fix_to_esf → compliance_check
+//   FIX TCP → fix_parse → fix_session → fix_to_data → compliance_check
 //     → order_validate → order_route → lex stream (trading.orders)
 //   lex stream (trading.fills) → settlement_bridge → data_to_fix → FIX TCP
 

--- a/fintech/fix-trading/fix_wire_adapter.fl
+++ b/fintech/fix-trading/fix_wire_adapter.fl
@@ -228,9 +228,9 @@ circuit fix_to_data_order(msg: FixParsedMessage) -> EStreamOrder
     let price = extract_fix_u64(msg.raw, 44, msg.raw_length)
     let tif_raw = extract_fix_u32(msg.raw, 59, msg.raw_length)
 
-    let side = fix_side_to_esf(side_raw)
-    let order_type = fix_ordtype_to_esf(ord_type_raw)
-    let time_in_force = fix_tif_to_esf(tif_raw)
+    let side = fix_side_to_data(side_raw)
+    let order_type = fix_ordtype_to_data(ord_type_raw)
+    let time_in_force = fix_tif_to_data(tif_raw)
 
     EStreamOrder {
         order_id: order_id,

--- a/fintech/iso20022/README.md
+++ b/fintech/iso20022/README.md
@@ -38,7 +38,7 @@ fpga/rtl/iso20022/
 ├── field_extractor.v            # Field extraction
 ├── field_extractor_parallel.v   # Parallel extraction
 ├── schema_rom.v                 # Field lookup table
-├── esf_output.v                 # ESF formatting
+├── data_output.v                # Data formatting
 ├── iso20022_parser_top.v        # Top-level module
 ├── iso20022_streamsight_bridge.v # Telemetry interface
 └── xml_template_engine.v        # XML generation
@@ -51,7 +51,7 @@ crates/estream-iso20022/
 │   │   ├── pacs008.rs
 │   │   └── pacs002.rs
 │   ├── schema.rs
-│   ├── esf.rs
+│   ├── data.rs
 │   └── types.rs
 └── benches/
     └── parser_benchmark.rs
@@ -69,7 +69,7 @@ The ESCIR circuit (`circuit.v080.escir.yaml`) defines the parser as a dataflow g
                          │                                      │
                          │                                      ▼
                    ┌─────┴─────┐                          ┌──────────────┐
-                   │ Tokenizer │                          │  ESF Output  │
+                   │ Tokenizer │                          │  Data Output  │
                    │   Mux     │                          └──────────────┘
                    └───────────┘                                │
                                                                 ▼
@@ -107,7 +107,7 @@ estream codegen --circuit circuit.v080.escir.yaml --target verilog --output pars
 use estream_fpga_bridge::Iso20022Parser;
 
 let parser = Iso20022Parser::new(FpgaDevice::open()?)?;
-let esf = parser.parse_xml(&xml_bytes)?;
+let data = parser.parse_xml(&xml_bytes)?;
 ```
 
 ### Native Rust
@@ -116,7 +116,7 @@ let esf = parser.parse_xml(&xml_bytes)?;
 use estream_iso20022::{Pacs008, parse_xml};
 
 let msg: Pacs008 = parse_xml(&xml_bytes)?;
-let esf = msg.to_esf()?;
+let data = msg.to_data()?;
 ```
 
 ### ESCIR→Rust (Generated)
@@ -126,14 +126,14 @@ let esf = msg.to_esf()?;
 use iso20022_parser::Iso20022ParserCircuit;
 
 let mut circuit = Iso20022ParserCircuit::new();
-let esf = circuit.execute(&input)?;
+let data = circuit.execute(&input)?;
 ```
 
 ## Testing
 
 ### Cross-Target Verification
 
-All three targets must produce identical ESF output for the same input:
+All three targets must produce identical Data output for the same input:
 
 ```bash
 # Run cross-target tests

--- a/industrial/specs/INDUSTRIAL_PROTOCOL_GATEWAY_V2.md
+++ b/industrial/specs/INDUSTRIAL_PROTOCOL_GATEWAY_V2.md
@@ -15,7 +15,7 @@
 This specification defines a **layered, composable architecture** for industrial protocol integration:
 
 1. **Transport Layer** - Generic TCP/UDP/Serial clients
-2. **Protocol Layer** - MODBUS, OPC-UA, DNP3 as ESF schemas
+2. **Protocol Layer** - MODBUS, OPC-UA, DNP3 as Data schemas
 3. **StreamSight Layer** - Unified telemetry and observability
 4. **ESCIR Circuits** - Open-source behavior definitions
 5. **Composite Components** - Marketplace SKUs
@@ -32,7 +32,7 @@ This specification defines a **layered, composable architecture** for industrial
 
 1. [Architecture Overview](#1-architecture-overview)
 2. [Transport Layer](#2-transport-layer)
-3. [Protocol Layer - ESF Schemas](#3-protocol-layer---esf-schemas)
+3. [Protocol Layer - Data Schemas](#3-protocol-layer---data-schemas)
 4. [StreamSight Integration](#4-streamsight-integration)
 5. [ESCIR Circuit Definitions](#5-escir-circuit-definitions)
 6. [Composite Components](#6-composite-components)
@@ -92,12 +92,12 @@ This specification defines a **layered, composable architecture** for industrial
 │  └────────────────────────────────────────────────────────────────────────┘ │
 │                                                                              │
 │  ┌────────────────────────────────────────────────────────────────────────┐ │
-│  │                      ESF Schema Layer (Open Source)                     │ │
+│  │                      Data Schema Layer (Open Source)                     │ │
 │  │                                                                         │ │
 │  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐   │ │
-│  │  │ modbus.esf  │  │ opcua.esf   │  │ dnp3.esf    │  │ industrial- │   │ │
+│  │  │ modbus.data  │  │ opcua.data   │  │ dnp3.data    │  │ industrial- │   │ │
 │  │  │             │  │             │  │             │  │ telemetry   │   │ │
-│  │  │ • MBAP      │  │ • UA Binary │  │ • Link      │  │ .esf        │   │ │
+│  │  │ • MBAP      │  │ • UA Binary │  │ • Link      │  │ .data        │   │ │
 │  │  │ • PDU       │  │ • Services  │  │ • Transport │  │             │   │ │
 │  │  │ • Functions │  │ • Types     │  │ • App       │  │ • Events    │   │ │
 │  │  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘   │ │
@@ -371,13 +371,13 @@ streamsight:
 
 ---
 
-## 3. Protocol Layer - ESF Schemas
+## 3. Protocol Layer - Data Schemas
 
 ### 3.1 MODBUS Protocol Schema
 
 ```yaml
-# schemas/modbus.esf.yaml
-esf: "1.0"
+# schemas/modbus.data.yaml
+data: "1.0"
 name: modbus
 version: "1.0.0"
 license: "Apache-2.0"
@@ -571,8 +571,8 @@ enums:
 ### 3.2 Industrial Telemetry Schema
 
 ```yaml
-# schemas/industrial-telemetry.esf.yaml
-esf: "1.0"
+# schemas/industrial-telemetry.data.yaml
+data: "1.0"
 name: industrial_telemetry
 version: "1.0.0"
 license: "Apache-2.0"
@@ -813,7 +813,7 @@ compute:
       
     - id: event_serializer
       type: transform
-      operation: esf_serialize
+      operation: data_serialize
       
     - id: topic_router
       type: lookup
@@ -1606,7 +1606,7 @@ pub struct ModbusSlaveSimulator {
 
 - [Component Marketplace Spec](./MARKETPLACE_SPEC.md)
 - [ESCIR Language Spec](../protocol/ESCIR_LANGUAGE_SPEC.md)
-- [ESF Schema Spec](../protocol/ESF_SCHEMA_SPEC.md)
+- [Data Schema Spec](../protocol/ESF_SCHEMA_SPEC.md)
 - [StreamSight Spec](../protocol/STREAMSIGHT_SPEC.md)
 - [ISO 20022 Parser Component](../../fpga/rtl/iso20022/COMPONENT_MARKETPLACE.md)
 

--- a/specs/ESTREAM_MARKETPLACE_SPEC.md
+++ b/specs/ESTREAM_MARKETPLACE_SPEC.md
@@ -11,7 +11,7 @@
 
 ## 1. Overview
 
-The eStream Marketplace is an open source component exchange — "npm for verifiable circuits" — enabling developers to discover, publish, install, and compose reusable eStream components: ESF schemas, SmartCircuits, protocol adapters, FPGA circuits, console widgets, and full-stack integrations.
+The eStream Marketplace is an open source component exchange — "npm for verifiable circuits" — enabling developers to discover, publish, install, and compose reusable eStream components: data schemas, SmartCircuits, protocol adapters, FPGA circuits, console widgets, and full-stack integrations.
 
 ### 1.1 Design Principles
 
@@ -28,7 +28,7 @@ Chronicle Software proved that open-sourcing high-performance middleware creates
 |-----------------|---------------|-----------------|
 | Chronicle Queue | **Queue Streams** — SmartCircuit-driven lex streams | `queue.append.v1` circuit → Witness → Lex Store |
 | Chronicle Map | **State Maps** — SmartCircuit-driven lex state | `map.put.v1` circuit → State Root → VRF Scatter |
-| Chronicle Wire | ESF — eStream Format | Exists |
+| Chronicle Wire | Data — eStream Data | Exists |
 | Chronicle Services | SmartCircuit runtime (BSL 1.1) | Exists |
 | Chronicle FIX | Wire adapters via `WireAdapter` trait | Circuit-wrapped protocol adapters |
 
@@ -36,7 +36,7 @@ Chronicle Software proved that open-sourcing high-performance middleware creates
 
 | Tier | License | Components |
 |------|---------|-----------|
-| **Open Source** | Apache 2.0 | Queue, Map, Wire adapters, ESF schemas, SDK |
+| **Open Source** | Apache 2.0 | Queue, Map, Wire adapters, data schemas, SDK |
 | **Source Available** | BSL 1.1 | FPGA acceleration, VRF Scatter HA, production runtime |
 | **Commercial** | Enterprise | Managed deployment, SLA, support, custom adapters |
 
@@ -50,7 +50,7 @@ Every publishable component belongs to one infrastructure category:
 
 | Category | Description | Examples |
 |----------|-------------|---------|
-| `esf-schema` | ESF schema packs | `esf-iot`, `esf-trading`, `esf-carbon` |
+| `data-schema` | data schema packs | `data-iot`, `data-trading`, `data-carbon` |
 | `wire-adapter` | Protocol adapters (impl `WireAdapter` trait) | `estream-wire-fix`, `estream-wire-mqtt` |
 | `smart-circuit` | Reusable SmartCircuit packages | `carbon-credit-mint`, `order-matcher` |
 | `fpga-circuit` | FPGA bitstream components | `ntt-accelerator`, `sha3-pipeline` |
@@ -122,7 +122,7 @@ pub enum SourceVisibility {
 
 **Always public** regardless of visibility level: name, version, publisher, input/output ports, resource requirements, estimated cost per execution, source hash.
 
-Visibility is implemented using ESF Filter — the same field-level privacy primitive used throughout the platform:
+Visibility is implemented using Data Filter — the same field-level privacy primitive used throughout the platform:
 
 ```rust
 pub struct FilteredComponentData {
@@ -177,7 +177,7 @@ min_version = "0.8.0"
 max_version = "1.0.0"   # optional
 
 [component.dependencies]
-esf-trading = "^1.0.0"
+data-trading = "^1.0.0"
 
 [component.schemas]
 provides = ["FixNewOrderSingle", "FixExecutionReport", "FixMarketData"]
@@ -216,7 +216,7 @@ fpga = ["fpga/*.bit"]
 ### 3.2 Name Conventions
 
 - **Format**: lowercase alphanumeric with hyphens (`[a-z0-9-]+`)
-- **Official prefixes**: `estream-*` and `esf-*` (reserved for eStream team)
+- **Official prefixes**: `estream-*` and `data-*` (reserved for eStream team)
 - **Third-party**: `@publisher/name` format (e.g., `@synergy-carbon/impact-counter`)
 
 ### 3.3 Version Requirements
@@ -242,7 +242,7 @@ my-component/
 ├── LICENSE                        # License file
 ├── CHANGELOG.md                   # Version history
 ├── schemas/
-│   └── *.data.yaml                # ESF schema definitions
+│   └── *.data.yaml                # data schema definitions
 ├── circuits/
 │   ├── *.fl                       # FastLang circuit definitions
 │   └── *.circuit.yaml             # ESCIR circuit definitions
@@ -477,8 +477,8 @@ estream-io/registry/
 ├── README.md
 ├── config.json
 ├── index/
-│   ├── esf-schema/
-│   │   └── esf-trading/
+│   ├── data-schema/
+│   │   └── data-trading/
 │   │       ├── metadata.json
 │   │       └── 1.0.0/
 │   │           ├── estream-component.toml
@@ -580,7 +580,7 @@ Cache TTL defaults to 24 hours. `estream marketplace install --force` bypasses c
 
 | Category | Install Path |
 |----------|-------------|
-| `esf-schema` | `schemas/` |
+| `data-schema` | `schemas/` |
 | `wire-adapter` | `adapters/` |
 | `smart-circuit` | `circuits/` |
 | `fpga-circuit` | `fpga/` |
@@ -594,7 +594,7 @@ After installation, components are tracked in `estream-workspace.toml`:
 ```toml
 [dependencies]
 estream-wire-fix = "1.0.0"
-esf-trading = "1.2.0"
+data-trading = "1.2.0"
 
 [dependencies.estream-wire-fix]
 version = "1.0.0"
@@ -1038,7 +1038,7 @@ The Sidebar gains a tab toggle: **Palette** | **Marketplace**. When Marketplace 
 │  Resources: T2 witness, 2K compute, 8KB mem                 │
 │  Est. cost: 0.003 ES/exec                                   │
 │                                                              │
-│  Dependencies: esf-trading ^1.0.0 (auto-installed)          │
+│  Dependencies: data-trading ^1.0.0 (auto-installed)          │
 │                                                              │
 │  [Install]  [View Source]  [View Docs]  [Add to Circuit]    │
 └──────────────────────────────────────────────────────────────┘
@@ -1118,11 +1118,11 @@ $ estream marketplace install estream-wire-fix@^1.0.0
 
   Resolving dependencies...
     estream-wire-fix v1.0.0
-    └── esf-trading v1.2.0
+    └── data-trading v1.2.0
 
   Verifying ML-DSA-87 signatures...
     estream-wire-fix v1.0.0 ✓ (key: estream-signing-key-01)
-    esf-trading v1.2.0 ✓ (key: estream-signing-key-01)
+    data-trading v1.2.0 ✓ (key: estream-signing-key-01)
 
   Installed 2 components (6 files) in 3.2s
 ```
@@ -1181,7 +1181,7 @@ Show detailed information for a specific component.
 | `E006` | `ChecksumMismatch` | SHA3-256 checksum mismatch |
 | `E007` | `UnknownPublisher` | Publisher key not in registry |
 | `E008` | `ManifestInvalid` | Manifest validation failed |
-| `E009` | `NameReserved` | Uses reserved `estream-*` or `esf-*` prefix |
+| `E009` | `NameReserved` | Uses reserved `estream-*` or `data-*` prefix |
 | `E010` | `VersionNotIncremented` | Version not higher than latest |
 | `E011` | `PackageTooLarge` | Archive exceeds 50 MB |
 | `E012` | `NetworkError` | Cannot reach registry |
@@ -1275,15 +1275,15 @@ default_key = "$HOME/.estream/keys/signing-key.pem"
 
 ## 19. Domain Schema Packs
 
-### 19.1 `esf-iot`
+### 19.1 `data-iot`
 
 IoT telemetry schemas: SensorReading, DeviceState, CommandEnvelope, AlertEvent, Geolocation.
 
-### 19.2 `esf-trading`
+### 19.2 `data-trading`
 
 Capital markets schemas: EStreamOrder, EStreamFill, EStreamQuote, EStreamMarketData.
 
-### 19.3 `esf-carbon`
+### 19.3 `data-carbon`
 
 Carbon/ESG schemas: CarbonCredit, EmissionReport, CarbonOffset, MethodologyAttestation.
 
@@ -1291,9 +1291,9 @@ Carbon/ESG schemas: CarbonCredit, EmissionReport, CarbonOffset, MethodologyAttes
 
 ```toml
 [component]
-name = "esf-iot"
+name = "data-iot"
 version = "1.0.0"
-category = "esf-schema"
+category = "data-schema"
 description = "IoT telemetry schemas for sensor networks"
 
 [component.schemas]
@@ -1331,7 +1331,7 @@ Future marketplace wire adapters:
 | Queue append | Throughput | > 1M msg/sec |
 | Map put/get | Latency (p99) | < 1μs |
 | Wire adapter (FIX) | Parse throughput | > 500K msg/sec |
-| ESF serialize | Throughput | > 2M msg/sec |
+| Data serialize | Throughput | > 2M msg/sec |
 
 ### FPGA Targets
 
@@ -1340,7 +1340,7 @@ Future marketplace wire adapters:
 | Queue append | Throughput | > 100M msg/sec |
 | Map put/get | Latency | < 100ns |
 | Wire adapter (FIX) | Parse throughput | > 50M msg/sec |
-| ESF serialize | Pipeline rate | 1 msg/clock cycle |
+| Data serialize | Pipeline rate | 1 msg/clock cycle |
 
 ---
 

--- a/streams/marketplace_streams.fl
+++ b/streams/marketplace_streams.fl
@@ -425,7 +425,7 @@ circuit marketplace_install_component(registry: bytes(32), deps: bytes(32), requ
 }
 
 // =============================================================================
-// Audience Declarations — Field-Level Visibility (ESF Filter)
+// Audience Declarations — Field-Level Visibility (Data Filter)
 // =============================================================================
 
 audience marketplace_public inherits authenticated

--- a/templates/estream-component.template.toml
+++ b/templates/estream-component.template.toml
@@ -6,13 +6,13 @@
 # Generate this file: estream marketplace scaffold <category> <name>
 
 [component]
-# Required: unique name (lowercase, hyphens). Official: estream-* or esf-*. Third-party: @publisher/name
+# Required: unique name (lowercase, hyphens). Official: estream-* or data-*. Third-party: @publisher/name
 name = "{{name}}"
 
 # Required: semantic version (major.minor.patch)
 version = "0.1.0"
 
-# Required: one of — esf-schema, wire-adapter, smart-circuit, fpga-circuit, integration, console-widget
+# Required: one of — data-schema, wire-adapter, smart-circuit, fpga-circuit, integration, console-widget
 category = "{{category}}"
 
 # Required: short description (one line)
@@ -44,7 +44,7 @@ min_version = "0.8.0"
 
 # Dependencies on other marketplace components (semver requirements)
 [component.dependencies]
-# esf-trading = "^1.0.0"
+# data-trading = "^1.0.0"
 # estream-kernel = ">=0.8.0"
 
 # Schemas this component provides and requires


### PR DESCRIPTION
## Summary

- Refactors `marketplace_streams.fl` from flat `data`/`stream` declarations to `graph marketplace_registry` + `dag component_dependencies` constructs
- Updates canonical spec §5 to describe graph-based data model
- Updates §6.4 version resolution to reference native DAG operations (enforce acyclic, topo_sort)

## What Changed

**`streams/marketplace_streams.fl`**:
- `graph marketplace_registry` with ComponentNode, PublisherNode, ReviewNode, LicenseNode as typed nodes
- Real-time overlays: download_count, active_installs, rating_x100, badges, revenue_es, vulnerability_count, signature_valid
- `ai_feed marketplace_recommendation` for trending/personalized suggestions
- `observe` with anomaly_score 0.85 for StreamSight escalation
- `series registry_series` for tamper-proof audit trail (Merkle, lattice imprint, witness attest)
- `dag component_dependencies` with version_conflict and install_order overlays
- Streams retained as lattice topic projections of graph state
- All data declarations, circuits, and audience declarations preserved

**`specs/ESTREAM_MARKETPLACE_SPEC.md`**:
- §5 rewritten from "Stream API" to "Data Model — Graph-Based Registry"
- §6.4 version resolution updated to reference DAG operations

## Context

The `graph`/`dag` construct (GRAPH_SPEC.md, 2,222 lines) is fully implemented across all 3 compiler backends (Rust, Verilog, WASM). The marketplace registry is modeled using the same patterns as the existing test corpus: device_mesh.fl, wallet_ledger.fl, governance.fl, expert_mesh.fl.

## Test plan

- [ ] Verify `marketplace_streams.fl` parses with FastLang compiler
- [ ] Verify graph/dag/series/overlay declarations follow test corpus conventions
- [ ] Review spec §5 and §6.4 updates for consistency with GRAPH_SPEC.md

Epic: polyquantum/estream#136